### PR TITLE
feat(app-web): フェーズ3 - 投稿機能UI実装

### DIFF
--- a/app-web/app/posts/page.tsx
+++ b/app-web/app/posts/page.tsx
@@ -1,0 +1,83 @@
+import { PostCard } from "@/components/PostCard";
+import { PostForm } from "@/components/PostForm";
+import { Post } from "@/types/post";
+
+// サンプルデータ
+const samplePosts: Post[] = [
+  {
+    id: "1",
+    author: {
+      name: "田中 太郎",
+      username: "tanaka_taro",
+      avatar: "https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?w=40&h=40&fit=crop&crop=face",
+    },
+    content: "今日は森でキツネに出会いました！とても美しい毛色で、しばらく見つめ合っていました。",
+    image: "https://images.unsplash.com/photo-1564349683136-77e08dba1ef7?w=500&h=300&fit=crop",
+    location: "北海道・知床国立公園",
+    coordinates: {
+      lat: 44.0877,
+      lng: 145.1278,
+    },
+    tags: ["キツネ", "野生動物", "知床", "自然観察"],
+    likes: 24,
+    comments: 5,
+    timestamp: "2時間前",
+    createdAt: new Date("2024-01-15T10:00:00Z"),
+    isLiked: false,
+  },
+  {
+    id: "2", 
+    author: {
+      name: "山田 花子",
+      username: "yamada_hanako",
+      avatar: "https://images.unsplash.com/photo-1438761681033-6461ffad8d80?w=40&h=40&fit=crop&crop=face",
+    },
+    content: "早朝の散歩でシカの親子に遭遇！子鹿がとても可愛かったです 🦌",
+    location: "奈良公園",
+    tags: ["シカ", "奈良", "親子"],
+    likes: 18,
+    comments: 3,
+    timestamp: "4時間前",
+    createdAt: new Date("2024-01-15T08:00:00Z"),
+    isLiked: true,
+  },
+  {
+    id: "3",
+    author: {
+      name: "佐藤 一郎",
+      username: "sato_ichiro", 
+      avatar: "https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?w=40&h=40&fit=crop&crop=face",
+    },
+    content: "リスがどんぐりを頬張る姿を激写！野生動物の自然な行動を観察できるのは本当に楽しいですね。",
+    image: "https://images.unsplash.com/photo-1564349683136-77e08dba1ef7?w=500&h=300&fit=crop",
+    location: "井の頭公園",
+    tags: ["リス", "どんぐり", "東京", "公園"],
+    likes: 31,
+    comments: 8,
+    timestamp: "6時間前", 
+    createdAt: new Date("2024-01-15T06:00:00Z"),
+    isLiked: false,
+  },
+];
+
+export default function PostsPage() {
+  return (
+    <div className="container mx-auto px-4 py-8 max-w-2xl">
+      <h1 className="text-3xl font-bold mb-8">投稿機能テスト</h1>
+      
+      {/* 投稿フォーム */}
+      <div className="mb-8">
+        <h2 className="text-xl font-semibold mb-4">投稿フォーム</h2>
+        <PostForm />
+      </div>
+      
+      {/* 投稿一覧 */}
+      <div className="space-y-6">
+        <h2 className="text-xl font-semibold">投稿カード</h2>
+        {samplePosts.map((post) => (
+          <PostCard key={post.id} post={post} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app-web/app/posts/page.tsx
+++ b/app-web/app/posts/page.tsx
@@ -1,61 +1,65 @@
-import { PostCard } from "@/components/PostCard";
-import { PostForm } from "@/components/PostForm";
-import { Post } from "@/types/post";
+import { PostCard } from '@/components/PostCard';
+import { PostForm } from '@/components/PostForm';
+import { Post } from '@/types/post';
 
 // サンプルデータ
 const samplePosts: Post[] = [
   {
-    id: "1",
+    id: '1',
     author: {
-      name: "田中 太郎",
-      username: "tanaka_taro",
-      avatar: "https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?w=40&h=40&fit=crop&crop=face",
+      name: '田中 太郎',
+      username: 'tanaka_taro',
+      avatar:
+        'https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?w=40&h=40&fit=crop&crop=face',
     },
-    content: "今日は森でキツネに出会いました！とても美しい毛色で、しばらく見つめ合っていました。",
-    image: "https://images.unsplash.com/photo-1564349683136-77e08dba1ef7?w=500&h=300&fit=crop",
-    location: "北海道・知床国立公園",
+    content: '今日は森でキツネに出会いました！とても美しい毛色で、しばらく見つめ合っていました。',
+    image: 'https://images.unsplash.com/photo-1564349683136-77e08dba1ef7?w=500&h=300&fit=crop',
+    location: '北海道・知床国立公園',
     coordinates: {
       lat: 44.0877,
       lng: 145.1278,
     },
-    tags: ["キツネ", "野生動物", "知床", "自然観察"],
+    tags: ['キツネ', '野生動物', '知床', '自然観察'],
     likes: 24,
     comments: 5,
-    timestamp: "2時間前",
-    createdAt: new Date("2024-01-15T10:00:00Z"),
+    timestamp: '2時間前',
+    createdAt: new Date('2024-01-15T10:00:00Z'),
     isLiked: false,
   },
   {
-    id: "2", 
+    id: '2',
     author: {
-      name: "山田 花子",
-      username: "yamada_hanako",
-      avatar: "https://images.unsplash.com/photo-1438761681033-6461ffad8d80?w=40&h=40&fit=crop&crop=face",
+      name: '山田 花子',
+      username: 'yamada_hanako',
+      avatar:
+        'https://images.unsplash.com/photo-1438761681033-6461ffad8d80?w=40&h=40&fit=crop&crop=face',
     },
-    content: "早朝の散歩でシカの親子に遭遇！子鹿がとても可愛かったです 🦌",
-    location: "奈良公園",
-    tags: ["シカ", "奈良", "親子"],
+    content: '早朝の散歩でシカの親子に遭遇！子鹿がとても可愛かったです 🦌',
+    location: '奈良公園',
+    tags: ['シカ', '奈良', '親子'],
     likes: 18,
     comments: 3,
-    timestamp: "4時間前",
-    createdAt: new Date("2024-01-15T08:00:00Z"),
+    timestamp: '4時間前',
+    createdAt: new Date('2024-01-15T08:00:00Z'),
     isLiked: true,
   },
   {
-    id: "3",
+    id: '3',
     author: {
-      name: "佐藤 一郎",
-      username: "sato_ichiro", 
-      avatar: "https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?w=40&h=40&fit=crop&crop=face",
+      name: '佐藤 一郎',
+      username: 'sato_ichiro',
+      avatar:
+        'https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?w=40&h=40&fit=crop&crop=face',
     },
-    content: "リスがどんぐりを頬張る姿を激写！野生動物の自然な行動を観察できるのは本当に楽しいですね。",
-    image: "https://images.unsplash.com/photo-1564349683136-77e08dba1ef7?w=500&h=300&fit=crop",
-    location: "井の頭公園",
-    tags: ["リス", "どんぐり", "東京", "公園"],
+    content:
+      'リスがどんぐりを頬張る姿を激写！野生動物の自然な行動を観察できるのは本当に楽しいですね。',
+    image: 'https://images.unsplash.com/photo-1564349683136-77e08dba1ef7?w=500&h=300&fit=crop',
+    location: '井の頭公園',
+    tags: ['リス', 'どんぐり', '東京', '公園'],
     likes: 31,
     comments: 8,
-    timestamp: "6時間前", 
-    createdAt: new Date("2024-01-15T06:00:00Z"),
+    timestamp: '6時間前',
+    createdAt: new Date('2024-01-15T06:00:00Z'),
     isLiked: false,
   },
 ];
@@ -64,13 +68,13 @@ export default function PostsPage() {
   return (
     <div className="container mx-auto px-4 py-8 max-w-2xl">
       <h1 className="text-3xl font-bold mb-8">投稿機能テスト</h1>
-      
+
       {/* 投稿フォーム */}
       <div className="mb-8">
         <h2 className="text-xl font-semibold mb-4">投稿フォーム</h2>
         <PostForm />
       </div>
-      
+
       {/* 投稿一覧 */}
       <div className="space-y-6">
         <h2 className="text-xl font-semibold">投稿カード</h2>

--- a/app-web/components/ImageWithFallback.tsx
+++ b/app-web/components/ImageWithFallback.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import React, { useState } from 'react';
+
+const ERROR_IMG_SRC =
+  'data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iODgiIGhlaWdodD0iODgiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgc3Ryb2tlPSIjMDAwIiBzdHJva2UtbGluZWpvaW49InJvdW5kIiBvcGFjaXR5PSIuMyIgZmlsbD0ibm9uZSIgc3Ryb2tlLXdpZHRoPSIzLjciPjxyZWN0IHg9IjE2IiB5PSIxNiIgd2lkdGg9IjU2IiBoZWlnaHQ9IjU2IiByeD0iNiIvPjxwYXRoIGQ9Im0xNiA1OCAxNi0xOCAzMiAzMiIvPjxjaXJjbGUgY3g9IjUzIiBjeT0iMzUiIHI9IjciLz48L3N2Zz4KCg==';
+
+export function ImageWithFallback(props: React.ImgHTMLAttributes<HTMLImageElement>) {
+  const [didError, setDidError] = useState(false);
+
+  const handleError = () => {
+    setDidError(true);
+  };
+
+  const { src, alt, style, className, ...rest } = props;
+
+  return didError ? (
+    <div
+      className={`inline-block bg-gray-100 text-center align-middle ${className ?? ''}`}
+      style={style}
+    >
+      <div className="flex items-center justify-center w-full h-full">
+        <img src={ERROR_IMG_SRC} alt="Error loading image" {...rest} data-original-url={src} />
+      </div>
+    </div>
+  ) : (
+    <img src={src} alt={alt} className={className} style={style} {...rest} onError={handleError} />
+  );
+}

--- a/app-web/components/PostCard.tsx
+++ b/app-web/components/PostCard.tsx
@@ -1,0 +1,112 @@
+'use client';
+
+import { useState } from 'react';
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardFooter, CardHeader } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Heart, MessageCircle, Share2, MapPin, MoreHorizontal } from 'lucide-react';
+import { ImageWithFallback } from '@/components/ImageWithFallback';
+import { Post } from '@/types/post';
+
+interface PostCardProps {
+  post: Post;
+}
+
+export function PostCard({ post }: PostCardProps) {
+  const [isLiked, setIsLiked] = useState(post.isLiked);
+  const [likesCount, setLikesCount] = useState(post.likes);
+
+  const handleLike = () => {
+    setIsLiked(!isLiked);
+    setLikesCount(isLiked ? likesCount - 1 : likesCount + 1);
+  };
+
+  return (
+    <Card className="w-full">
+      <CardHeader className="pb-3">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center space-x-3">
+            <Avatar className="h-10 w-10">
+              <AvatarImage src={post.author.avatar} alt={post.author.name} />
+              <AvatarFallback>{post.author.name[0]}</AvatarFallback>
+            </Avatar>
+            <div>
+              <p className="text-sm font-medium">{post.author.name}</p>
+              <div className="flex items-center text-xs text-muted-foreground space-x-2">
+                <span>@{post.author.username}</span>
+                <span>•</span>
+                <span>{post.timestamp}</span>
+                {post.location && (
+                  <>
+                    <span>•</span>
+                    <div className="flex items-center">
+                      <MapPin className="h-3 w-3 mr-1" />
+                      <span>{post.location}</span>
+                    </div>
+                  </>
+                )}
+              </div>
+            </div>
+          </div>
+          <Button variant="ghost" size="icon" className="h-8 w-8">
+            <MoreHorizontal className="h-4 w-4" />
+            <span className="sr-only">その他のオプション</span>
+          </Button>
+        </div>
+      </CardHeader>
+
+      <CardContent className="pb-3">
+        {post.content && <p className="mb-3">{post.content}</p>}
+
+        {post.image && (
+          <div className="rounded-lg overflow-hidden mb-3">
+            <ImageWithFallback
+              src={post.image}
+              alt="投稿画像"
+              className="w-full h-auto object-cover"
+            />
+          </div>
+        )}
+
+        {post.tags.length > 0 && (
+          <div className="flex flex-wrap gap-2">
+            {post.tags.map((tag, index) => (
+              <Badge key={index} variant="secondary" className="text-xs">
+                #{tag}
+              </Badge>
+            ))}
+          </div>
+        )}
+      </CardContent>
+
+      <CardFooter className="pt-0">
+        <div className="flex items-center justify-between w-full">
+          <div className="flex items-center space-x-4">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={handleLike}
+              className={`text-muted-foreground hover:text-red-500 ${
+                isLiked ? 'text-red-500' : ''
+              }`}
+            >
+              <Heart className={`h-4 w-4 mr-1 ${isLiked ? 'fill-current' : ''}`} />
+              <span className="sr-only">いいね</span>
+              {likesCount}
+            </Button>
+            <Button variant="ghost" size="sm" className="text-muted-foreground hover:text-blue-500">
+              <MessageCircle className="h-4 w-4 mr-1" />
+              <span className="sr-only">コメント</span>
+              {post.comments}
+            </Button>
+          </div>
+          <Button variant="ghost" size="sm" className="text-muted-foreground hover:text-green-500">
+            <Share2 className="h-4 w-4" />
+            <span className="sr-only">シェア</span>
+          </Button>
+        </div>
+      </CardFooter>
+    </Card>
+  );
+}

--- a/app-web/components/PostForm.tsx
+++ b/app-web/components/PostForm.tsx
@@ -1,0 +1,108 @@
+'use client';
+
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
+import { Textarea } from '@/components/ui/textarea';
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import { ImagePlus, MapPin, Tag } from 'lucide-react';
+import { ImageWithFallback } from '@/components/ImageWithFallback';
+
+export function PostForm() {
+  const [content, setContent] = useState('');
+  const [selectedImage, setSelectedImage] = useState<string | null>(null);
+
+  const handleImageSelect = () => {
+    // 実際の実装では、ファイル選択ダイアログを開く
+    // 今は仮の画像URLを設定
+    const imageUrl =
+      'https://images.unsplash.com/photo-1564349683136-77e08dba1ef7?w=500&h=300&fit=crop';
+    setSelectedImage(imageUrl);
+  };
+
+  const handlePost = () => {
+    if (content.trim() || selectedImage) {
+      // 実際の実装では、投稿をサーバーに送信
+      console.log('投稿:', { content, image: selectedImage });
+      setContent('');
+      setSelectedImage(null);
+    }
+  };
+
+  return (
+    <Card className="w-full">
+      <CardHeader className="pb-3">
+        <div className="flex items-center space-x-3">
+          <Avatar className="h-10 w-10">
+            <AvatarImage
+              src="https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?w=40&h=40&fit=crop&crop=face"
+              alt="あなた"
+            />
+            <AvatarFallback>あ</AvatarFallback>
+          </Avatar>
+          <Textarea
+            placeholder="今日はどんな野生動物に出会いましたか？"
+            value={content}
+            onChange={(e) => setContent(e.target.value)}
+            className="flex-1 min-h-[80px] resize-none border-0 p-0 focus-visible:ring-0 bg-transparent"
+          />
+        </div>
+      </CardHeader>
+
+      {selectedImage && (
+        <CardContent className="pt-0">
+          <div className="relative rounded-lg overflow-hidden">
+            <ImageWithFallback
+              src={selectedImage}
+              alt="選択された画像"
+              className="w-full h-64 object-cover"
+            />
+            <Button
+              variant="secondary"
+              size="sm"
+              className="absolute top-2 right-2"
+              onClick={() => setSelectedImage(null)}
+            >
+              削除
+            </Button>
+          </div>
+        </CardContent>
+      )}
+
+      <CardContent className="pt-0">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center space-x-2">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={handleImageSelect}
+              className="text-muted-foreground hover:text-primary"
+            >
+              <ImagePlus className="h-4 w-4 mr-1" />
+              <span className="sr-only">写真を追加</span>
+              写真
+            </Button>
+            <Button variant="ghost" size="sm" className="text-muted-foreground hover:text-primary">
+              <MapPin className="h-4 w-4 mr-1" />
+              <span className="sr-only">場所を追加</span>
+              場所
+            </Button>
+            <Button variant="ghost" size="sm" className="text-muted-foreground hover:text-primary">
+              <Tag className="h-4 w-4 mr-1" />
+              <span className="sr-only">タグを追加</span>
+              タグ
+            </Button>
+          </div>
+
+          <Button
+            onClick={handlePost}
+            disabled={!content.trim() && !selectedImage}
+            className="bg-primary hover:bg-primary/90"
+          >
+            投稿
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/app-web/components/ui/textarea.tsx
+++ b/app-web/components/ui/textarea.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+function Textarea({ className, ...props }: React.ComponentProps<'textarea'>) {
+  return (
+    <textarea
+      data-slot="textarea"
+      className={cn(
+        'border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 flex field-sizing-content min-h-16 w-full rounded-md border bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Textarea };

--- a/app-web/package.json
+++ b/app-web/package.json
@@ -6,7 +6,7 @@
     "node": "24.x"
   },
   "scripts": {
-    "dev": "next dev --turbopack",
+    "dev": "next dev --turbopack --port 23000",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",

--- a/app-web/types/post.ts
+++ b/app-web/types/post.ts
@@ -1,0 +1,21 @@
+export interface Post {
+  id: string;
+  author: {
+    name: string;
+    username: string;
+    avatar: string;
+  };
+  content: string;
+  image?: string;
+  location?: string;
+  coordinates?: {
+    lat: number;
+    lng: number;
+  };
+  tags: string[];
+  likes: number;
+  comments: number;
+  timestamp: string;
+  createdAt: Date;
+  isLiked: boolean;
+}


### PR DESCRIPTION
## Motivation

SOWフェーズ3の実装として、投稿関連のUIコンポーネントを実装し、SNSライクな投稿機能の基盤を構築。
実際のデータ永続化とファイルアップロードは後のフェーズで実装予定。

## Changes

### コンポーネント追加
- **Textareaコンポーネント**: shadcn/uiから追加
- **ImageWithFallbackコンポーネント**: 画像読み込みエラー時のフォールバック機能
- **Post型定義**: 投稿データ構造のTypeScript定義

### PostCardコンポーネント
- ユーザー情報表示（アバター、名前、ユーザー名）
- タイムスタンプ、位置情報表示
- 投稿内容、画像表示機能
- タグ表示（Badge）
- インタラクション機能
  - いいねボタン（クリックで状態変化）
  - コメント数表示
  - シェアボタン

### PostFormコンポーネント
- テキスト入力（Textarea）
- 画像選択機能（仮実装 - クリックで仮画像表示）
- 位置情報、タグボタン（UI のみ）
- 投稿ボタン（バリデーション付き）

### テストページ
- `/posts`パスで動作確認可能
- サンプルデータ3件（キツネ、シカ、リスの投稿）
- PostFormとPostCardの統合表示

### 開発環境改善
- 開発サーバーのポートを23000に変更（他環境との競合回避）
- 新しいアクセスURL: http://localhost:23000

## Remarks

- 画像アップロードは仮実装（実際のファイル選択は後のフェーズ）
- データ永続化なし（useState での状態管理のみ）
- アクセシビリティ対応済み（スクリーンリーダー、キーボードナビゲーション）
- レスポンシブデザイン対応

## Test Plan

- [x] http://localhost:23000/posts にアクセス
- [ ] 投稿フォームでテキスト入力確認
- [ ] 写真ボタンクリックで画像プレビュー表示確認
- [ ] いいねボタンクリックで状態変化確認
- [ ] 投稿ボタンのバリデーション確認（テキストor画像必須）
- [x] 各コンポーネントのレスポンシブ表示確認

🤖 Generated with [Claude Code](https://claude.ai/code)