### PR TITLE
Phase 5: ビュー切り替え機能の実装 (#6)

### DIFF
--- a/app-web/app/globals.css
+++ b/app-web/app/globals.css
@@ -1,5 +1,6 @@
 @import 'tailwindcss';
 @import 'tw-animate-css';
+@import 'leaflet/dist/leaflet.css';
 
 @custom-variant dark (&:is(.dark *));
 

--- a/app-web/app/page.tsx
+++ b/app-web/app/page.tsx
@@ -5,8 +5,11 @@ import { Feed } from '@/components/Feed';
 import { PostForm } from '@/components/PostForm';
 import { ViewSwitcher, ViewMode } from '@/components/ViewSwitcher';
 import { FeedFilter, FilterOptions } from '@/components/FeedFilter';
+import { CalendarView } from '@/components/CalendarView';
+import { MapView } from '@/components/MapView';
 import { mockPosts } from '@/data/mockPosts';
 import { filterPosts, getUniqueTagsFromPosts } from '@/lib/filterPosts';
+import type { Post } from '@/lib/data';
 
 export default function Home() {
   const [currentView, setCurrentView] = useState<ViewMode>('list');
@@ -19,22 +22,19 @@ export default function Home() {
   const availableTags = useMemo(() => getUniqueTagsFromPosts(mockPosts), []);
   const filteredPosts = useMemo(() => filterPosts(mockPosts, filters), [filters]);
 
+  const handlePostClick = (post: Post) => {
+    // 将来的にはモーダル表示やルーティングを実装
+    console.log('Post clicked:', post);
+  };
+
   const renderContent = () => {
     switch (currentView) {
       case 'list':
         return <Feed initialPosts={filteredPosts} />;
       case 'calendar':
-        return (
-          <div className="flex items-center justify-center py-12 text-gray-500">
-            <p>カレンダービュー（Phase 5で実装予定）</p>
-          </div>
-        );
+        return <CalendarView posts={filteredPosts} onPostClick={handlePostClick} />;
       case 'map':
-        return (
-          <div className="flex items-center justify-center py-12 text-gray-500">
-            <p>マップビュー（Phase 5で実装予定）</p>
-          </div>
-        );
+        return <MapView posts={filteredPosts} onPostClick={handlePostClick} />;
       default:
         return <Feed initialPosts={filteredPosts} />;
     }

--- a/app-web/components/CalendarView.tsx
+++ b/app-web/components/CalendarView.tsx
@@ -1,0 +1,204 @@
+'use client';
+
+import { useState, useMemo } from 'react';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { PostCard } from './PostCard';
+import type { Post } from '@/lib/data';
+
+interface CalendarViewProps {
+  posts: Post[];
+  onPostClick: (post: Post) => void;
+}
+
+export function CalendarView({ posts, onPostClick }: CalendarViewProps) {
+  const [currentDate, setCurrentDate] = useState(new Date());
+  const [selectedDate, setSelectedDate] = useState<Date | null>(null);
+
+  // 月曜始まりのカレンダーにするため調整
+  const startDate = useMemo(() => {
+    const firstDayOfMonth = new Date(currentDate.getFullYear(), currentDate.getMonth(), 1);
+    const date = new Date(firstDayOfMonth);
+    const dayOfWeek = date.getDay();
+    const daysToSubtract = dayOfWeek === 0 ? 6 : dayOfWeek - 1;
+    date.setDate(date.getDate() - daysToSubtract);
+    return date;
+  }, [currentDate]);
+
+  // カレンダーの最終日（6週分表示）
+  const endDate = useMemo(() => {
+    const date = new Date(startDate);
+    date.setDate(date.getDate() + 41);
+    return date;
+  }, [startDate]);
+
+  // 日付ごとの投稿をグループ化
+  const postsByDate = useMemo(() => {
+    const grouped: Record<string, Post[]> = {};
+    posts.forEach((post) => {
+      const date = new Date(post.createdAt);
+      const key = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`;
+      if (!grouped[key]) {
+        grouped[key] = [];
+      }
+      grouped[key].push(post);
+    });
+    return grouped;
+  }, [posts]);
+
+  // 選択日の投稿
+  const selectedPosts = useMemo(() => {
+    if (!selectedDate) return [];
+    const key = `${selectedDate.getFullYear()}-${String(selectedDate.getMonth() + 1).padStart(2, '0')}-${String(selectedDate.getDate()).padStart(2, '0')}`;
+    return postsByDate[key] || [];
+  }, [selectedDate, postsByDate]);
+
+  // カレンダーの日付配列を生成
+  const calendarDays = useMemo(() => {
+    const days = [];
+    const current = new Date(startDate);
+
+    while (current <= endDate) {
+      days.push(new Date(current));
+      current.setDate(current.getDate() + 1);
+    }
+
+    return days;
+  }, [startDate, endDate]);
+
+  const navigateToPreviousMonth = () => {
+    setCurrentDate(new Date(currentDate.getFullYear(), currentDate.getMonth() - 1));
+    setSelectedDate(null);
+  };
+
+  const navigateToNextMonth = () => {
+    setCurrentDate(new Date(currentDate.getFullYear(), currentDate.getMonth() + 1));
+    setSelectedDate(null);
+  };
+
+  const formatMonthYear = (date: Date) => {
+    return new Intl.DateTimeFormat('ja-JP', {
+      year: 'numeric',
+      month: 'long',
+    }).format(date);
+  };
+
+  const getDayKey = (date: Date) => {
+    return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`;
+  };
+
+  const isToday = (date: Date) => {
+    const today = new Date();
+    return (
+      date.getFullYear() === today.getFullYear() &&
+      date.getMonth() === today.getMonth() &&
+      date.getDate() === today.getDate()
+    );
+  };
+
+  const isSelected = (date: Date) => {
+    if (!selectedDate) return false;
+    return (
+      date.getFullYear() === selectedDate.getFullYear() &&
+      date.getMonth() === selectedDate.getMonth() &&
+      date.getDate() === selectedDate.getDate()
+    );
+  };
+
+  const isCurrentMonth = (date: Date) => {
+    return (
+      date.getMonth() === currentDate.getMonth() && date.getFullYear() === currentDate.getFullYear()
+    );
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="bg-white rounded-lg shadow-sm border border-gray-200">
+        <div className="p-4">
+          <div className="flex items-center justify-between mb-4">
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={navigateToPreviousMonth}
+              aria-label="前月へ"
+            >
+              <ChevronLeft className="h-5 w-5" />
+            </Button>
+            <h2 className="text-lg font-semibold">{formatMonthYear(currentDate)}</h2>
+            <Button variant="ghost" size="icon" onClick={navigateToNextMonth} aria-label="翌月へ">
+              <ChevronRight className="h-5 w-5" />
+            </Button>
+          </div>
+
+          <div className="grid grid-cols-7 gap-1 mb-2">
+            {['月', '火', '水', '木', '金', '土', '日'].map((day) => (
+              <div key={day} className="text-center text-sm font-medium text-gray-700 py-2">
+                {day}
+              </div>
+            ))}
+          </div>
+
+          <div className="grid grid-cols-7 gap-1">
+            {calendarDays.map((date, index) => {
+              const key = getDayKey(date);
+              const dayPosts = postsByDate[key] || [];
+              const hasPost = dayPosts.length > 0;
+              const isInCurrentMonth = isCurrentMonth(date);
+
+              return (
+                <button
+                  key={index}
+                  onClick={() => setSelectedDate(date)}
+                  className={`
+                    relative aspect-square p-1 text-sm
+                    transition-colors rounded-lg
+                    ${isInCurrentMonth ? 'text-gray-900' : 'text-gray-400'}
+                    ${isToday(date) ? 'bg-blue-100 font-bold' : ''}
+                    ${isSelected(date) ? 'bg-blue-500 text-white' : 'hover:bg-gray-100'}
+                  `}
+                  aria-label={`${date.getDate()}日${hasPost ? ` - ${dayPosts.length}件の投稿` : ''}`}
+                >
+                  <span className="block">{date.getDate()}</span>
+                  {hasPost && (
+                    <span
+                      className={`
+                      absolute bottom-1 right-1 w-5 h-5
+                      rounded-full text-xs font-medium
+                      flex items-center justify-center
+                      ${isSelected(date) ? 'bg-white text-blue-500' : 'bg-blue-500 text-white'}
+                    `}
+                    >
+                      {dayPosts.length}
+                    </span>
+                  )}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+
+      {selectedDate && (
+        <div className="space-y-4">
+          <h3 className="text-lg font-semibold">
+            {selectedDate.toLocaleDateString('ja-JP', {
+              year: 'numeric',
+              month: 'long',
+              day: 'numeric',
+            })}
+            の投稿
+          </h3>
+          {selectedPosts.length > 0 ? (
+            <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+              {selectedPosts.map((post) => (
+                <PostCard key={post.id} post={post} onClick={() => onPostClick(post)} />
+              ))}
+            </div>
+          ) : (
+            <p className="text-gray-500 text-center py-8">この日の投稿はありません</p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app-web/components/MapView.tsx
+++ b/app-web/components/MapView.tsx
@@ -1,0 +1,150 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import dynamic from 'next/dynamic';
+import { PostCard } from './PostCard';
+import type { Post } from '@/lib/data';
+import { setupLeafletIcons } from '@/lib/leaflet';
+
+// Leafletを動的インポート（SSR対策）
+const MapContainer = dynamic(() => import('react-leaflet').then((mod) => mod.MapContainer), {
+  ssr: false,
+  loading: () => <div className="h-96 bg-gray-100 animate-pulse rounded-lg" />,
+});
+
+const TileLayer = dynamic(() => import('react-leaflet').then((mod) => mod.TileLayer), {
+  ssr: false,
+});
+
+const Marker = dynamic(() => import('react-leaflet').then((mod) => mod.Marker), { ssr: false });
+
+const Popup = dynamic(() => import('react-leaflet').then((mod) => mod.Popup), { ssr: false });
+
+interface MapViewProps {
+  posts: Post[];
+  onPostClick: (post: Post) => void;
+}
+
+export function MapView({ posts, onPostClick }: MapViewProps) {
+  const [selectedPost, setSelectedPost] = useState<Post | null>(null);
+  const [isClient, setIsClient] = useState(false);
+
+  useEffect(() => {
+    setIsClient(true);
+    if (typeof window !== 'undefined') {
+      setupLeafletIcons();
+    }
+  }, []);
+
+  // 位置情報を持つ投稿のみフィルタリング
+  const geotaggedPosts = posts.filter(
+    (post) => post.location?.latitude && post.location?.longitude
+  );
+
+  // 位置情報のない投稿
+  const nonGeotaggedPosts = posts.filter(
+    (post) => !post.location?.latitude || !post.location?.longitude
+  );
+
+  // 地図の中心点を計算（投稿の平均位置、または東京をデフォルトに）
+  const calculateCenter = (): [number, number] => {
+    if (geotaggedPosts.length === 0) {
+      return [35.6762, 139.6503]; // 東京
+    }
+
+    const sumLat = geotaggedPosts.reduce((sum, post) => sum + (post.location?.latitude || 0), 0);
+    const sumLng = geotaggedPosts.reduce((sum, post) => sum + (post.location?.longitude || 0), 0);
+
+    return [sumLat / geotaggedPosts.length, sumLng / geotaggedPosts.length];
+  };
+
+  const center = calculateCenter();
+
+  if (!isClient) {
+    return <div className="h-96 bg-gray-100 animate-pulse rounded-lg" />;
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-4">
+        <h2 className="text-lg font-semibold mb-4">投稿マップ</h2>
+
+        <div className="h-[500px] rounded-lg overflow-hidden">
+          <MapContainer center={center} zoom={10} className="h-full w-full">
+            <TileLayer
+              attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+              url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+            />
+
+            {geotaggedPosts.map((post) => {
+              if (!post.location?.latitude || !post.location?.longitude) return null;
+
+              return (
+                <Marker
+                  key={post.id}
+                  position={[post.location.latitude, post.location.longitude]}
+                  eventHandlers={{
+                    click: () => {
+                      setSelectedPost(post);
+                    },
+                  }}
+                >
+                  <Popup>
+                    <div className="w-64">
+                      <h3 className="font-semibold mb-2">{post.author.name}</h3>
+                      {post.imageUrl && (
+                        <img
+                          src={post.imageUrl}
+                          alt="投稿画像"
+                          className="w-full h-32 object-cover rounded mb-2"
+                        />
+                      )}
+                      <p className="text-sm text-gray-600 mb-2">
+                        {post.content.length > 100
+                          ? post.content.substring(0, 100) + '...'
+                          : post.content}
+                      </p>
+                      <button
+                        onClick={() => onPostClick(post)}
+                        className="text-blue-500 hover:text-blue-600 text-sm font-medium"
+                      >
+                        詳細を見る
+                      </button>
+                    </div>
+                  </Popup>
+                </Marker>
+              );
+            })}
+          </MapContainer>
+        </div>
+
+        <div className="mt-4 flex items-center justify-between">
+          <p className="text-sm text-gray-600">位置情報付き: {geotaggedPosts.length}件</p>
+          <p className="text-sm text-gray-600">位置情報なし: {nonGeotaggedPosts.length}件</p>
+        </div>
+      </div>
+
+      {selectedPost && (
+        <div className="space-y-4">
+          <h3 className="text-lg font-semibold">選択中の投稿</h3>
+          <div className="max-w-md">
+            <PostCard post={selectedPost} onClick={() => onPostClick(selectedPost)} />
+          </div>
+        </div>
+      )}
+
+      {nonGeotaggedPosts.length > 0 && (
+        <div className="space-y-4">
+          <h3 className="text-lg font-semibold">
+            位置情報のない投稿 ({nonGeotaggedPosts.length}件)
+          </h3>
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {nonGeotaggedPosts.map((post) => (
+              <PostCard key={post.id} post={post} onClick={() => onPostClick(post)} />
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app-web/components/ViewSwitcher.tsx
+++ b/app-web/components/ViewSwitcher.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import React from 'react';
 import { LayoutGrid, Calendar, MapPin } from 'lucide-react';
 
 export type ViewMode = 'list' | 'calendar' | 'map';

--- a/app-web/lib/leaflet.ts
+++ b/app-web/lib/leaflet.ts
@@ -1,0 +1,13 @@
+import L from 'leaflet';
+
+// Leafletのアイコン設定を修正（Next.jsのパス問題対策）
+export const setupLeafletIcons = () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  delete (L.Icon.Default.prototype as any)._getIconUrl;
+
+  L.Icon.Default.mergeOptions({
+    iconRetinaUrl: '/leaflet/marker-icon-2x.png',
+    iconUrl: '/leaflet/marker-icon.png',
+    shadowUrl: '/leaflet/marker-shadow.png',
+  });
+};

--- a/app-web/package-lock.json
+++ b/app-web/package-lock.json
@@ -15,13 +15,16 @@
         "@radix-ui/react-separator": "^1.1.7",
         "@radix-ui/react-slot": "^1.2.3",
         "@radix-ui/react-tabs": "^1.1.13",
+        "@types/leaflet": "^1.9.20",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "leaflet": "^1.9.4",
         "lucide-react": "^0.542.0",
         "next": "15.4.6",
         "next-pwa": "^5.6.0",
         "react": "19.1.0",
         "react-dom": "19.1.0",
+        "react-leaflet": "^5.0.0",
         "tailwind-merge": "^3.3.1"
       },
       "devDependencies": {
@@ -3204,6 +3207,17 @@
       "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
       "license": "MIT"
     },
+    "node_modules/@react-leaflet/core": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@react-leaflet/core/-/core-3.0.0.tgz",
+      "integrity": "sha512-3EWmekh4Nz+pGcr+xjf0KNyYfC3U2JjnkWsh0zcqaexYqmmB5ZhH37kz41JXGmKzpaMZCnPofBBm64i+YrEvGQ==",
+      "license": "Hippocratic-2.1",
+      "peerDependencies": {
+        "leaflet": "^1.9.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0"
+      }
+    },
     "node_modules/@rollup/plugin-babel": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-babel/-/plugin-babel-5.3.1.tgz",
@@ -3663,6 +3677,12 @@
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "license": "MIT"
     },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "license": "MIT"
+    },
     "node_modules/@types/glob": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz",
@@ -3685,6 +3705,15 @@
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/leaflet": {
+      "version": "1.9.20",
+      "resolved": "https://registry.npmjs.org/@types/leaflet/-/leaflet-1.9.20.tgz",
+      "integrity": "sha512-rooalPMlk61LCaLOvBF2VIf9M47HgMQqi5xQ9QRi7c8PkdIe0WrIi5IxXUXQjAdL0c+vcQ01mYWbthzmp9GHWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
     },
     "node_modules/@types/minimatch": {
       "version": "5.1.2",
@@ -7529,6 +7558,12 @@
         "node": ">=0.10"
       }
     },
+    "node_modules/leaflet": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
+      "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
+      "license": "BSD-2-Clause"
+    },
     "node_modules/leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -8757,6 +8792,20 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-leaflet": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/react-leaflet/-/react-leaflet-5.0.0.tgz",
+      "integrity": "sha512-CWbTpr5vcHw5bt9i4zSlPEVQdTVcML390TjeDG0cK59z1ylexpqC6M1PJFjV8jD7CF+ACBFsLIDs6DRMoLEofw==",
+      "license": "Hippocratic-2.1",
+      "dependencies": {
+        "@react-leaflet/core": "^3.0.0"
+      },
+      "peerDependencies": {
+        "leaflet": "^1.9.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0"
+      }
     },
     "node_modules/react-remove-scroll": {
       "version": "2.7.1",

--- a/app-web/package.json
+++ b/app-web/package.json
@@ -21,13 +21,16 @@
     "@radix-ui/react-separator": "^1.1.7",
     "@radix-ui/react-slot": "^1.2.3",
     "@radix-ui/react-tabs": "^1.1.13",
+    "@types/leaflet": "^1.9.20",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "leaflet": "^1.9.4",
     "lucide-react": "^0.542.0",
     "next": "15.4.6",
     "next-pwa": "^5.6.0",
     "react": "19.1.0",
     "react-dom": "19.1.0",
+    "react-leaflet": "^5.0.0",
     "tailwind-merge": "^3.3.1"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

Phase 5として、CalendarViewとMapViewコンポーネントを実装し、完全なビュー切り替え機能を提供しました。

- ✅ CalendarView: 月表示カレンダーUI、投稿数バッジ、日付選択による投稿表示
- ✅ MapView: Leaflet地図表示、マーカークリック機能、位置情報なし投稿の別表示  
- ✅ ビュー間状態管理: フィルター状態の保持
- ✅ 依存関係追加: leaflet, react-leaflet, @types/leaflet

## 実装詳細

### CalendarView
- 月曜始まりの日本形式カレンダー
- 投稿がある日付への投稿数バッジ表示
- 日付クリックで該当日の投稿一覧表示
- 月/年のナビゲーション機能
- フィルター機能と連携

### MapView
- OpenStreetMap による地図表示
- 位置情報付き投稿のマーカー表示
- マーカークリックでPopup表示
- 位置情報なし投稿の別エリア表示
- 動的インポートによるSSR対応

### 統合機能
- HomeページでのViewSwitcherとの完全統合
- フィルター状態の各ビュー間での保持
- 投稿クリック時のコールバック設定

## Test plan

- [ ] ブラウザでアプリケーションを起動して各ビューが正常に表示されることを確認
- [ ] カレンダービューで日付選択・月ナビゲーションが動作することを確認
- [ ] マップビューで地図・マーカーが正常に表示されることを確認
- [ ] フィルター適用時に各ビューで適切に反映されることを確認
- [ ] ビュー切り替え時に状態が保持されることを確認

Fixes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)